### PR TITLE
feat: implement about us page with dynamic content

### DIFF
--- a/src/app/(frontend)/about-us/_components/FeaturesGrid.tsx
+++ b/src/app/(frontend)/about-us/_components/FeaturesGrid.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+// The 'icon' from Payload is a string, assuming it's for an icon class or emoji
+// The 'id' is automatically added by Payload for array fields
+type Feature = {
+  id: string
+  icon: string
+  title: string
+  description: string
+}
+
+type FeaturesGridProps = {
+  features: Feature[]
+}
+
+const FeaturesGrid: React.FC<FeaturesGridProps> = ({ features }) => {
+  if (!features || features.length === 0) {
+    return null
+  }
+
+  return (
+    <section className="features-grid py-12">
+      <div className="container mx-auto px-4">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+          {features.map((feature) => (
+            <Card key={feature.id} className="text-center">
+              <CardHeader>
+                {/* We'll just display the icon string for now. This could be an emoji or a class for an icon font. */}
+                <div className="text-4xl mb-4">{feature.icon}</div>
+                <CardTitle>{feature.title}</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className="text-gray-600">{feature.description}</p>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export default FeaturesGrid

--- a/src/app/(frontend)/about-us/_components/Hero.tsx
+++ b/src/app/(frontend)/about-us/_components/Hero.tsx
@@ -1,0 +1,25 @@
+export default function Hero({
+  title,
+  backgroundImage,
+}: {
+  title: string
+  backgroundImage?: { url?: string }
+}) {
+  const bgUrl = backgroundImage?.url || '/fallback-image.jpg' // Use a fallback image or empty string
+
+  return (
+    <div
+      className="relative h-[400px] flex items-center justify-center"
+      style={{
+        backgroundImage: `url(${bgUrl})`,
+        backgroundSize: 'cover',
+        backgroundPosition: 'center',
+      }}
+    >
+      <div className="absolute inset-0 bg-black/40" />
+      <h1 className="relative text-white text-4xl md:text-5xl font-bold z-10 text-center px-4">
+        {title}
+      </h1>
+    </div>
+  )
+}

--- a/src/app/(frontend)/about-us/_components/TeamSection.tsx
+++ b/src/app/(frontend)/about-us/_components/TeamSection.tsx
@@ -1,0 +1,41 @@
+import Image from 'next/image'
+
+type TeamMember = {
+  profileImage: { url: string }
+  name: string
+  role: string
+}
+
+type TeamSectionProps = {
+  title: string
+  members: TeamMember[]
+}
+
+function TeamMemberCard({ member }: { member: TeamMember }) {
+  return (
+    <div className="flex flex-col items-center m-4">
+      <Image
+        src={member.profileImage.url}
+        alt={member.name}
+        width={150}
+        height={150}
+        className="w-36 h-36 rounded-full object-cover border-4 border-white shadow-lg"
+      />
+      <h4 className="mt-2 font-semibold">{member.name}</h4>
+      <p className="text-gray-600">{member.role}</p>
+    </div>
+  )
+}
+
+export default function TeamSection({ title, members = [] }: TeamSectionProps) {
+  return (
+    <section className="py-12 bg-gray-50">
+      <h2 className="text-2xl font-bold text-center mb-8">{title}</h2>
+      <div className="flex flex-wrap justify-center">
+        {members.map((member) => (
+          <TeamMemberCard key={member.name} member={member} />
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/app/(frontend)/about-us/page.tsx
+++ b/src/app/(frontend)/about-us/page.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import RichText from '@/components/RichText'
+import Hero from './_components/Hero'
+import TeamSection from './_components/TeamSection'
+import FeaturesGrid from './_components/FeaturesGrid'
+
+// Helper to fetch the about-us page from Payload
+async function getAboutPageData() {
+  const aboutPageReq = await fetch(
+    `${process.env.NEXT_PUBLIC_PAYLOAD_URL}/api/globals/about-page`,
+    { cache: 'no-store' },
+  )
+  const aboutPageData = await aboutPageReq.json()
+
+  const teamMembersReq = await fetch(`${process.env.NEXT_PUBLIC_PAYLOAD_URL}/api/team-members`, {
+    cache: 'no-store',
+  })
+  const teamMembersData = await teamMembersReq.json()
+
+  return { aboutPageData, teamMembersData: teamMembersData.docs }
+}
+
+export default async function AboutUsPage() {
+  const { aboutPageData, teamMembersData } = await getAboutPageData()
+
+  return (
+    <div>
+      <Hero {...aboutPageData.hero} />
+      <section className="about-us-content">
+        {/* Render the intro section */}
+        <h2 className="text-2xl font-bold mb-4">{aboutPageData.introSection?.title}</h2>
+        <RichText data={aboutPageData.introSection?.content} />
+      </section>
+      <FeaturesGrid features={aboutPageData.featuresGrid} />
+      <section className="about-us-detailed">
+        <RichText data={aboutPageData.detailedContent} />
+      </section>
+      <TeamSection title={aboutPageData.teamSectionTitle} members={teamMembersData || []} />
+    </div>
+  )
+}

--- a/src/collections/TeamMembers.ts
+++ b/src/collections/TeamMembers.ts
@@ -1,0 +1,20 @@
+import { CollectionConfig } from 'payload/types'
+import { anyone } from '../access/anyone'
+
+const TeamMembers: CollectionConfig = {
+  slug: 'team-members',
+  admin: {
+    useAsTitle: 'name',
+  },
+  access: {
+    read: anyone,
+  },
+  fields: [
+    { name: 'name', type: 'text', required: true },
+    { name: 'role', type: 'text', required: true },
+    { name: 'profileImage', type: 'upload', relationTo: 'media', required: true },
+    // Add more fields as needed (bio, email, etc.)
+  ],
+}
+
+export default TeamMembers

--- a/src/globals/About.ts
+++ b/src/globals/About.ts
@@ -1,0 +1,58 @@
+import { GlobalConfig } from 'payload/types'
+import { anyone } from '../access/anyone'
+
+const About: GlobalConfig = {
+  slug: 'about-page',
+  access: {
+    read: anyone,
+  },
+  fields: [
+    {
+      name: 'hero',
+      type: 'group',
+      fields: [
+        { name: 'title', type: 'text', required: true },
+        { name: 'backgroundImage', type: 'upload', relationTo: 'media', required: true },
+      ],
+    },
+    {
+      name: 'introSection',
+      type: 'group',
+      fields: [
+        { name: 'title', type: 'text', required: true },
+        { name: 'content', type: 'richText', required: true },
+      ],
+    },
+    {
+      name: 'featuresGrid',
+      type: 'array',
+      fields: [
+        { name: 'icon', type: 'text', required: true },
+        { name: 'title', type: 'text', required: true },
+        { name: 'description', type: 'textarea', required: true },
+      ],
+    },
+    {
+      name: 'detailedContent',
+      type: 'richText',
+      required: true,
+    },
+    {
+      name: 'volunteerCta',
+      type: 'group',
+      fields: [
+        { name: 'title', type: 'text', required: true },
+        { name: 'buttonText', type: 'text', required: true },
+        { name: 'buttonLink', type: 'text', required: true },
+        { name: 'image', type: 'upload', relationTo: 'media', required: true },
+      ],
+    },
+    {
+      name: 'teamSectionTitle',
+      type: 'text',
+      required: true,
+    },
+  ],
+}
+
+export default About

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -72,6 +72,7 @@ export interface Config {
     media: Media;
     categories: Category;
     users: User;
+    'team-members': TeamMember;
     redirects: Redirect;
     forms: Form;
     'form-submissions': FormSubmission;
@@ -88,6 +89,7 @@ export interface Config {
     media: MediaSelect<false> | MediaSelect<true>;
     categories: CategoriesSelect<false> | CategoriesSelect<true>;
     users: UsersSelect<false> | UsersSelect<true>;
+    'team-members': TeamMembersSelect<false> | TeamMembersSelect<true>;
     redirects: RedirectsSelect<false> | RedirectsSelect<true>;
     forms: FormsSelect<false> | FormsSelect<true>;
     'form-submissions': FormSubmissionsSelect<false> | FormSubmissionsSelect<true>;
@@ -103,10 +105,12 @@ export interface Config {
   globals: {
     header: Header;
     footer: Footer;
+    'about-page': AboutPage;
   };
   globalsSelect: {
     header: HeaderSelect<false> | HeaderSelect<true>;
     footer: FooterSelect<false> | FooterSelect<true>;
+    'about-page': AboutPageSelect<false> | AboutPageSelect<true>;
   };
   locale: null;
   user: User & {
@@ -781,6 +785,18 @@ export interface Form {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "team-members".
+ */
+export interface TeamMember {
+  id: string;
+  name: string;
+  role: string;
+  profileImage: string | Media;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "redirects".
  */
 export interface Redirect {
@@ -971,6 +987,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'users';
         value: string | User;
+      } | null)
+    | ({
+        relationTo: 'team-members';
+        value: string | TeamMember;
       } | null)
     | ({
         relationTo: 'redirects';
@@ -1389,6 +1409,17 @@ export interface UsersSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "team-members_select".
+ */
+export interface TeamMembersSelect<T extends boolean = true> {
+  name?: T;
+  role?: T;
+  profileImage?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "redirects_select".
  */
 export interface RedirectsSelect<T extends boolean = true> {
@@ -1712,6 +1743,67 @@ export interface Footer {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "about-page".
+ */
+export interface AboutPage {
+  id: string;
+  hero: {
+    title: string;
+    backgroundImage: string | Media;
+  };
+  introSection: {
+    title: string;
+    content: {
+      root: {
+        type: string;
+        children: {
+          type: string;
+          version: number;
+          [k: string]: unknown;
+        }[];
+        direction: ('ltr' | 'rtl') | null;
+        format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+        indent: number;
+        version: number;
+      };
+      [k: string]: unknown;
+    };
+  };
+  featuresGrid?:
+    | {
+        icon: string;
+        title: string;
+        description: string;
+        id?: string | null;
+      }[]
+    | null;
+  detailedContent: {
+    root: {
+      type: string;
+      children: {
+        type: string;
+        version: number;
+        [k: string]: unknown;
+      }[];
+      direction: ('ltr' | 'rtl') | null;
+      format: 'left' | 'start' | 'center' | 'right' | 'end' | 'justify' | '';
+      indent: number;
+      version: number;
+    };
+    [k: string]: unknown;
+  };
+  volunteerCta: {
+    title: string;
+    buttonText: string;
+    buttonLink: string;
+    image: string | Media;
+  };
+  teamSectionTitle: string;
+  updatedAt?: string | null;
+  createdAt?: string | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "header_select".
  */
 export interface HeaderSelect<T extends boolean = true> {
@@ -1762,6 +1854,45 @@ export interface FooterSelect<T extends boolean = true> {
             };
         id?: T;
       };
+  updatedAt?: T;
+  createdAt?: T;
+  globalType?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "about-page_select".
+ */
+export interface AboutPageSelect<T extends boolean = true> {
+  hero?:
+    | T
+    | {
+        title?: T;
+        backgroundImage?: T;
+      };
+  introSection?:
+    | T
+    | {
+        title?: T;
+        content?: T;
+      };
+  featuresGrid?:
+    | T
+    | {
+        icon?: T;
+        title?: T;
+        description?: T;
+        id?: T;
+      };
+  detailedContent?: T;
+  volunteerCta?:
+    | T
+    | {
+        title?: T;
+        buttonText?: T;
+        buttonLink?: T;
+        image?: T;
+      };
+  teamSectionTitle?: T;
   updatedAt?: T;
   createdAt?: T;
   globalType?: T;

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -16,6 +16,8 @@ import { Header } from './Header/config'
 import { plugins } from './plugins'
 import { defaultLexical } from '@/fields/defaultLexical'
 import { getServerSideURL } from './utilities/getURL'
+import About from './globals/About'
+import TeamMembers from './collections/TeamMembers'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -62,9 +64,9 @@ export default buildConfig({
   db: mongooseAdapter({
     url: process.env.MONGODB_URI || '',
   }),
-  collections: [Pages, Posts, Media, Categories, Users],
+  collections: [Pages, Posts, Media, Categories, Users, TeamMembers],
   cors: [getServerSideURL()].filter(Boolean),
-  globals: [Header, Footer],
+  globals: [Header, Footer, About],
   plugins: [
     ...plugins,
     vercelBlobStorage({


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added a new About Us page that loads content and team members dynamically from the CMS.

- **New Features**
  - About Us page with hero, intro, features, detailed content, and team section.
  - Team members and page content are managed through new CMS collections and globals.

<!-- End of auto-generated description by cubic. -->

