### PR TITLE
Add NoticeSidebar component and integrate with homepage

### DIFF
--- a/src/components/NoticeSidebar.tsx
+++ b/src/components/NoticeSidebar.tsx
@@ -1,0 +1,197 @@
+import React, { useEffect, useRef, useState } from 'react'
+import { Media } from './Media'
+import RichText from './RichText'
+
+interface NoticeSidebarProps {
+  open: boolean
+  onClose: () => void
+  notice: {
+    title: string
+    category: string
+    summary?: string
+    image?: any
+    content?: any
+  } | null
+}
+
+const categoryLabel: Record<string, string> = {
+  ecosystem: 'Ecosystem',
+  species: 'Species',
+  community: 'Community',
+  policy: 'Policy',
+}
+
+export const NoticeSidebar: React.FC<NoticeSidebarProps> = ({ open, onClose, notice }) => {
+  const sidebarRef = useRef<HTMLDivElement>(null)
+  const [imageModalOpen, setImageModalOpen] = useState(false)
+
+  // Close on ESC for sidebar and modal
+  useEffect(() => {
+    if (!open && !imageModalOpen) return
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        if (imageModalOpen) setImageModalOpen(false)
+        else onClose()
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [open, onClose, imageModalOpen])
+
+  // Close sidebar on click outside
+  useEffect(() => {
+    if (!open) return
+    const handleClick = (e: MouseEvent) => {
+      if (sidebarRef.current && !sidebarRef.current.contains(e.target as Node)) {
+        onClose()
+      }
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [open, onClose])
+
+  // Close image modal on click outside
+  const imageModalRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    if (!imageModalOpen) return
+    const handleClick = (e: MouseEvent) => {
+      if (imageModalRef.current && !imageModalRef.current.contains(e.target as Node)) {
+        setImageModalOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [imageModalOpen])
+
+  useEffect(() => {
+    // Reset image modal when notice changes or sidebar opens
+    setImageModalOpen(false)
+  }, [notice, open])
+
+  return (
+    <div
+      className={`fixed inset-0 z-50 transition-all duration-300 ${open ? 'pointer-events-auto' : 'pointer-events-none'}`}
+      aria-hidden={!open}
+    >
+      {/* Overlay */}
+      <div
+        className={`absolute inset-0 bg-black/30 transition-opacity duration-300 ${open ? 'opacity-100' : 'opacity-0'}`}
+        onClick={onClose}
+      />
+      {/* Sidebar */}
+      <div
+        ref={sidebarRef}
+        className={`fixed top-0 right-0 h-full bg-white shadow-2xl w-[45vw] max-w-xl transition-transform duration-300 flex flex-col overflow-y-auto
+          ${open ? 'translate-x-0' : 'translate-x-full'}`}
+        style={{ minWidth: 320 }}
+      >
+        <button
+          className="absolute top-4 right-4 z-10 p-2 rounded-full bg-gray-100 hover:bg-gray-200 transition"
+          onClick={onClose}
+          aria-label="Close sidebar"
+        >
+          <svg
+            className="w-6 h-6 text-gray-600"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+        {notice && (
+          <div className="p-8 pt-14 overflow-x-hidden">
+            <div className="mb-4">
+              <span className="text-xs font-semibold uppercase tracking-wider text-blue-600">
+                {categoryLabel[notice.category] || notice.category}
+              </span>
+              <h2 className="mt-1 text-2xl font-bold text-mainBlue break-words">{notice.title}</h2>
+            </div>
+            {notice.summary && <p className="mb-4 text-gray-600 text-base">{notice.summary}</p>}
+            {notice.image && typeof notice.image === 'object' && (
+              <div
+                className="mb-6 w-full flex justify-center items-center border bg-gray-100 cursor-zoom-in relative group"
+                style={{ maxHeight: '60vh' }}
+                onClick={() => setImageModalOpen(true)}
+                title="Click to enlarge"
+              >
+                <Media
+                  resource={notice.image}
+                  fill={false}
+                  imgClassName="object-contain max-h-[60vh] w-auto h-auto"
+                />
+                {/* Magnifier icon overlay */}
+                <div className="absolute bottom-2 right-2 bg-white/80 rounded-full p-1 shadow group-hover:scale-110 transition-transform">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="w-6 h-6 text-gray-700"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M21 21l-4.35-4.35m0 0A7.5 7.5 0 104.5 4.5a7.5 7.5 0 0012.15 12.15z"
+                    />
+                  </svg>
+                  {/* Tooltip */}
+                  <span className="absolute bottom-10 right-0 mb-1 px-2 py-1 text-xs text-white bg-black/80 rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap z-50">
+                    Click to enlarge
+                  </span>
+                </div>
+              </div>
+            )}
+            {notice.content && (
+              <div className="prose max-w-none break-words">
+                <RichText data={notice.content} />
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+      {/* Image Modal */}
+      {imageModalOpen && notice?.image && typeof notice.image === 'object' && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80">
+          <div
+            ref={imageModalRef}
+            className="relative flex flex-col items-center bg-white rounded shadow-lg max-w-[80vw] max-h-[80vh] p-4"
+          >
+            <button
+              className="absolute top-2 right-2 z-10 p-2 rounded-full bg-white/80 hover:bg-white transition"
+              onClick={() => setImageModalOpen(false)}
+              aria-label="Close image modal"
+            >
+              <svg
+                className="w-6 h-6 text-gray-800"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+            <Media
+              resource={notice.image}
+              fill={false}
+              imgClassName="object-contain max-w-[75vw] max-h-[70vh] w-auto h-auto"
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default NoticeSidebar

--- a/src/heros/home-page-notice-v1/index.tsx
+++ b/src/heros/home-page-notice-v1/index.tsx
@@ -6,6 +6,7 @@ import { Media } from '@/components/Media'
 import { CMSLink } from '@/components/Link'
 import { getClientSideURL } from '@/utilities/getURL'
 import { useHeaderTheme } from '@/providers/HeaderTheme'
+import NoticeSidebar from '@/components/NoticeSidebar'
 
 interface Notice {
   id: string
@@ -38,6 +39,8 @@ export const HomePageNoticeV1Hero: React.FC<Page['hero']> = ({
   buttonText,
 }) => {
   const [notices, setNotices] = useState<Notice[]>([])
+  const [sidebarOpen, setSidebarOpen] = useState(false)
+  const [selectedNotice, setSelectedNotice] = useState<Notice | null>(null)
   const { setHeaderTheme } = useHeaderTheme()
 
   useEffect(() => {
@@ -57,6 +60,16 @@ export const HomePageNoticeV1Hero: React.FC<Page['hero']> = ({
 
     fetchNotices()
   }, [])
+
+  const handleNoticeClick = (notice: Notice) => {
+    setSelectedNotice(notice)
+    setSidebarOpen(true)
+  }
+
+  const handleSidebarClose = () => {
+    setSidebarOpen(false)
+    setSelectedNotice(null)
+  }
 
   return (
     <div className="bg-gradient-to-br from-slate-50 via-white to-blue-50/30 mb-48">
@@ -123,8 +136,9 @@ export const HomePageNoticeV1Hero: React.FC<Page['hero']> = ({
               {notices.map((notice, index) => (
                 <article
                   key={notice.id}
-                  className="group relative bg-white/60 backdrop-blur-sm border border-white/40 p-1 hover:bg-white/80 hover:border-white/60 transition-all duration-300 hover:shadow-lg hover:shadow-slate-900/5 hover:-translate-y-1"
+                  className="group relative bg-white/60 backdrop-blur-sm border border-white/40 p-1 hover:bg-white/80 hover:border-white/60 transition-all duration-300 hover:shadow-lg hover:shadow-slate-900/5 hover:-translate-y-1 cursor-pointer"
                   style={{ animationDelay: `${index * 100}ms` }}
+                  onClick={() => handleNoticeClick(notice)}
                 >
                   <div className="flex items-start gap-4">
                     <div className="flex-1 min-w-0 space-y-3">
@@ -138,14 +152,9 @@ export const HomePageNoticeV1Hero: React.FC<Page['hero']> = ({
                         </span>
                       </div>
 
-                      <CMSLink
-                        url={`/notices/${notice.slug || notice.id}`}
-                        className="block group-hover:text-blue-600 transition-colors duration-200"
-                      >
-                        <h3 className="font-semibold text-slate-900 text-lg leading-snug line-clamp-2 group-hover:text-blue-600 transition-colors duration-200">
-                          <span className="text-sm">{notice.title}</span>
-                        </h3>
-                      </CMSLink>
+                      <h3 className="font-semibold text-slate-900 text-lg leading-snug line-clamp-2 group-hover:text-blue-600 transition-colors duration-200">
+                        <span className="text-sm">{notice.title}</span>
+                      </h3>
 
                       {notice.summary && (
                         <p className="text-sm text-slate-600 line-clamp-2 leading-relaxed">
@@ -153,39 +162,14 @@ export const HomePageNoticeV1Hero: React.FC<Page['hero']> = ({
                         </p>
                       )}
                     </div>
-
-                    {notice.image && typeof notice.image === 'object' && (
-                      <div className="flex-shrink-0 w-16 h-16 overflow-hidden bg-slate-100 shadow-md">
-                        <Media resource={notice.image} fill imgClassName="object-cover" />
-                      </div>
-                    )}
                   </div>
-
-                  <CMSLink
-                    url={`/notices/${notice.slug || notice.id}`}
-                    aria-label={`Read more about ${notice.title}`}
-                    className="absolute top-4 right-4 w-8 h-8 bg-slate-100 hover:bg-slate-200 flex items-center justify-center transition-all duration-200 opacity-0 group-hover:opacity-100 hover:scale-110"
-                  >
-                    <svg
-                      className="w-4 h-4 text-slate-600"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                      stroke="currentColor"
-                    >
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M9 5l7 7-7 7"
-                      />
-                    </svg>
-                  </CMSLink>
                 </article>
               ))}
             </div>
           </div>
         </div>
       </div>
+      <NoticeSidebar open={sidebarOpen} onClose={handleSidebarClose} notice={selectedNotice} />
     </div>
   )
 }


### PR DESCRIPTION
### **User description**
Introduces a new NoticeSidebar component for displaying notice details in a sidebar modal. Updates the home-page-notice-v1 hero to use the sidebar for notice details instead of linking to a separate page, improving user experience with in-place detail viewing.


___

### **PR Type**
Enhancement


___

### **Description**
- Add NoticeSidebar component for in-place notice viewing

- Replace notice page links with sidebar modal

- Implement image zoom functionality with modal

- Add keyboard and click-outside close handlers


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Notice Card"] -- "Click" --> B["NoticeSidebar"]
  B -- "Display" --> C["Notice Details"]
  C -- "Image Click" --> D["Image Modal"]
  B -- "ESC/Outside Click" --> E["Close Sidebar"]
  D -- "ESC/Outside Click" --> F["Close Modal"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NoticeSidebar.tsx</strong><dd><code>New NoticeSidebar component with modal functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/components/NoticeSidebar.tsx

<li>Create new sidebar component with slide-in animation<br> <li> Add image zoom modal with click-to-enlarge functionality<br> <li> Implement keyboard navigation and click-outside handlers<br> <li> Include category labels and rich text content rendering


</details>


  </td>
  <td><a href="https://github.com/koiralaprijun00/payload-website-starter/pull/12/files#diff-27e1e86270bc89454da8ff415682fe62fc7476cffd35225fb5efddcaeebad6f1">+197/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.tsx</strong><dd><code>Integrate NoticeSidebar with homepage notices</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/heros/home-page-notice-v1/index.tsx

<li>Replace CMSLink navigation with sidebar modal<br> <li> Add state management for sidebar and selected notice<br> <li> Remove image thumbnails and read-more buttons<br> <li> Integrate NoticeSidebar component with click handlers


</details>


  </td>
  <td><a href="https://github.com/koiralaprijun00/payload-website-starter/pull/12/files#diff-75d6fd0a830f32b5e1d04520be2989c59556af02d911c0ffe1588a05d6672061">+19/-35</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a sidebar panel for viewing detailed notice information without leaving the current page.
  * Added image zoom functionality within the sidebar, allowing users to enlarge notice images in a modal.
  * Enhanced accessibility and smooth animations for sidebar and modal interactions.

* **Refactor**
  * Updated notice list items to open the sidebar on click instead of navigating to a separate page.
  * Removed redundant links and image blocks from the notice list for a streamlined user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->